### PR TITLE
Updated the SpeechSynthesizer state machine, add desync detection

### DIFF
--- a/BlueWizard/SpeechSynthesizer.mm
+++ b/BlueWizard/SpeechSynthesizer.mm
@@ -4,8 +4,16 @@
 #import "tms5220.h"
 #import "UserSettings.h"
 
+#define SPEAK_EXTERNAL_COMMAND 0x60
+#define RESET_COMMAND 0xFF
+#define SAMPLES_PER_HALF_FRAME (200)
+#define STATUS_TS_MASK 0x80
+#define STATUS_BL_MASK 0x40
+#define STATUS_BE_MASK 0x20
+
 @interface SpeechSynthesizer ()
 @property (nonatomic, getter = isSpeaking) BOOL speaking;
+@property (nonatomic, getter = hasStartedTalking) BOOL startedTalking;
 @property (nonatomic) NSUInteger sampleRate;
 @property (nonatomic) NSUInteger index;
 @end
@@ -36,18 +44,19 @@
 -(Buffer *)processSpeechData:(NSArray *)lpc {
     NSAssert(!self.speaking, @"already speaking!");
 
+    self.startedTalking = NO;
     self.speaking = YES;
     NSMutableArray *samples = [NSMutableArray arrayWithCapacity:65536];
     
     _tms5220->set_use_raw_excitation_filter([[self userSettings] excitationFilterOnly]);
     
-    [self writeData:0x60];
+    [self writeData:SPEAK_EXTERNAL_COMMAND];
     
     while (self.isSpeaking) {
         [self speakFragment:lpc samples:samples];
     }
     
-    [self writeData:0xff];
+    [self writeData:RESET_COMMAND];
     
     return [self bufferFor:samples];
 }
@@ -68,36 +77,83 @@
 }
 
 -(void)fillBuffer:(NSMutableArray *)samples {
-    unsigned int frames = _tms5220->m_fifo_count;
-    short int buffer[frames];
-    _tms5220->process(buffer, frames);
+    short int buffer[SAMPLES_PER_HALF_FRAME];
+    _tms5220->process(buffer, SAMPLES_PER_HALF_FRAME);
     float scale = 1.0f / (1 << 15);
-    for (int i = 0; i < frames; i++) {
+    for (int i = 0; i < SAMPLES_PER_HALF_FRAME; i++) {
         [samples addObject:[NSNumber numberWithDouble:buffer[i] * scale]];
     }
 }
 
 -(void)writeData:(int)data {
-    _tms5220->wsq_w(1);
+    //_tms5220->wsq_w(1); // don't use these since we want to use the 5220 without worrying about timing the reads and writes
     _tms5220->data_w(data);
-    _tms5220->wsq_w(0);
+    //_tms5220->wsq_w(0);
+}
+
+-(int)readStatus {
+    int tms_status;
+    //_tms5220->rsq_w(1); // don't use these since we want to use the 5220 without worrying about timing the reads and writes
+    tms_status = _tms5220->status_r();
+    //_tms5220->rsq_w(0);
+    NSLog(@"5220 DEBUG: Index: %lu, Status read: TS: %d, BL: %d, BE: %d, Started: %d", self.index, (tms_status&0x80)?1:0, (tms_status&0x40)?1:0, (tms_status&0x20)?1:0, self.hasStartedTalking);
+    return tms_status;
 }
 
 -(void)speakFragment:(NSArray *)speechData
              samples:(NSMutableArray *)samples {
-    while (!_tms5220->m_ready_pin) {
-        [self fillBuffer:samples];
+    // if the chip hasn't started talking yet, load the fifo with enough bytes to either unset the BL mask and get speech going, or enough that we've run out of input data.
+    if (!(self.hasStartedTalking)) {
+        while ( (self.index < ([speechData count] - 1)) && ([self readStatus]&STATUS_BL_MASK) ) {
+            [self writeData:[[speechData objectAtIndex:self.index] intValue]];
+            self.index += 1;
+        }
     }
     
-    [self writeData:[[speechData objectAtIndex:self.index] intValue]];
+    [self fillBuffer:samples];
+
+    // has the chip actually ever started talking yet?
+    if ( (!(self.hasStartedTalking)) && ([self readStatus]&STATUS_TS_MASK) ) {
+        self.startedTalking = YES;
+    }
     
-    if (self.index == [speechData count] - 1) {
+    // if we ran out of input data and never even started talking, give up, go home.
+    if ( (!(self.hasStartedTalking)) && (self.index >= ([speechData count] - 1)) ) {
+        NSLog(@"fatal tms5220 error: insufficient speech data (<9 bytes) to start synthesizing speech. Try adding a few silence frames to the end.");
         self.speaking = NO;
-        self.index    = 0;
+        self.index = 0;
         return;
     }
     
-    self.index += 1;
+    if (self.hasStartedTalking) {
+        // if we're talking, we need to keep the tms5220 fifo as full as we can.
+        if (self.index < ([speechData count] - 1)) {
+            // if we still have input data to send, try to fill the fifo until we run out of data or BL goes inactive
+            while ( (self.index < ([speechData count] - 1)) && ([self readStatus]&STATUS_BL_MASK) ) {
+                [self writeData:[[speechData objectAtIndex:self.index] intValue]];
+                self.index += 1;
+            }
+        }
+        else {
+            // we're all out of input data!
+            if (!([self readStatus]&STATUS_TS_MASK)) {
+                // if talk status went inactive, shut everything down, we're done.
+                self.speaking = NO;
+                self.index = 0;
+                return;
+            }
+            // if ts is still active and we're out of data, continue onward since we need to finish up speaking what's in the fifo.
+        }
+    }
+        
+    
+    // if we exited speak external mode due to a stop frame in the middle of everything or a general desync, BAIL OUT! Otherwise we get gibberish speak or crashes or other non-fun stuff.
+    if (_tms5220->m_DDIS == 0) {
+        NSLog(@"Fatal tms5220 error, we've desynced and we're no longer in speak external mode. Bailing out.");
+        self.speaking = NO;
+        self.index    = 0;
+    }
+        
 }
 
 -(UserSettings *)userSettings {

--- a/BlueWizard/SpeechSynthesizer.mm
+++ b/BlueWizard/SpeechSynthesizer.mm
@@ -13,7 +13,6 @@
 
 @interface SpeechSynthesizer ()
 @property (nonatomic, getter = isSpeaking) BOOL speaking;
-@property (nonatomic, getter = hasStartedTalking) BOOL startedTalking;
 @property (nonatomic) NSUInteger sampleRate;
 @property (nonatomic) NSUInteger index;
 @end
@@ -44,7 +43,6 @@
 -(Buffer *)processSpeechData:(NSArray *)lpc {
     NSAssert(!self.speaking, @"already speaking!");
 
-    self.startedTalking = NO;
     self.speaking = YES;
     NSMutableArray *samples = [NSMutableArray arrayWithCapacity:65536];
     
@@ -96,64 +94,47 @@
     //_tms5220->rsq_w(1); // don't use these since we want to use the 5220 without worrying about timing the reads and writes
     tms_status = _tms5220->status_r();
     //_tms5220->rsq_w(0);
-    NSLog(@"5220 DEBUG: Index: %lu, Status read: TS: %d, BL: %d, BE: %d, Started: %d", self.index, (tms_status&0x80)?1:0, (tms_status&0x40)?1:0, (tms_status&0x20)?1:0, self.hasStartedTalking);
+    //NSLog(@"5220 DEBUG: Index: %lu, Status read: TS: %d, BL: %d, BE: %d", self.index, (tms_status&0x80)?1:0, (tms_status&0x40)?1:0, (tms_status&0x20)?1:0);
     return tms_status;
 }
 
 -(void)speakFragment:(NSArray *)speechData
              samples:(NSMutableArray *)samples {
-    // if the chip hasn't started talking yet, load the fifo with enough bytes to either unset the BL mask and get speech going, or enough that we've run out of input data.
-    if (!(self.hasStartedTalking)) {
-        while ( (self.index < ([speechData count] - 1)) && ([self readStatus]&STATUS_BL_MASK) ) {
+    // If the chip hasn't started talking yet, and we have yet to send any data...
+    if ( !([self readStatus]&STATUS_TS_MASK) && (self.index == 0) ) {
+        // Load the fifo with enough bytes to either unset the BL mask and get speech going, or enough that we've run out of input data.
+        while ( (self.index <= ([speechData count] - 1)) && ([self readStatus]&STATUS_BL_MASK) ) {
             [self writeData:[[speechData objectAtIndex:self.index] intValue]];
             self.index += 1;
         }
+        // If we ran out of input data and never even filled the fifo, bail out.
+        if ( (self.index > ([speechData count] - 1)) && ([self readStatus]&STATUS_BL_MASK) ) {
+            //NSLog(@"TMS5220 error: insufficient speech data (<9 bytes) to start synthesizing speech");
+            self.speaking = NO;
+            self.index = 0;
+            return;
+        }
     }
-    
-    [self fillBuffer:samples];
-
-    // has the chip actually ever started talking yet?
-    if ( (!(self.hasStartedTalking)) && ([self readStatus]&STATUS_TS_MASK) ) {
-        self.startedTalking = YES;
-    }
-    
-    // if we ran out of input data and never even started talking, give up, go home.
-    if ( (!(self.hasStartedTalking)) && (self.index >= ([speechData count] - 1)) ) {
-        NSLog(@"fatal tms5220 error: insufficient speech data (<9 bytes) to start synthesizing speech. Try adding a few silence frames to the end.");
-        self.speaking = NO;
-        self.index = 0;
-        return;
-    }
-    
-    if (self.hasStartedTalking) {
-        // if we're talking, we need to keep the tms5220 fifo as full as we can.
-        if (self.index < ([speechData count] - 1)) {
-            // if we still have input data to send, try to fill the fifo until we run out of data or BL goes inactive
-            while ( (self.index < ([speechData count] - 1)) && ([self readStatus]&STATUS_BL_MASK) ) {
+    else {
+        // We're either talking or have finished talking. First check if there's any data left to send...
+        if (self.index <= ([speechData count] - 1)) {
+            // We still have input data to send, so try to fill the fifo until we run out of data or BL goes inactive
+            while ( (self.index <= ([speechData count] - 1)) && ([self readStatus]&STATUS_BL_MASK) ) {
                 [self writeData:[[speechData objectAtIndex:self.index] intValue]];
                 self.index += 1;
             }
         }
-        else {
-            // we're all out of input data!
-            if (!([self readStatus]&STATUS_TS_MASK)) {
-                // if talk status went inactive, shut everything down, we're done.
-                self.speaking = NO;
-                self.index = 0;
-                return;
-            }
-            // if ts is still active and we're out of data, continue onward since we need to finish up speaking what's in the fifo.
+        // Now, no matter if we have data left to send or not, check the talk status line. if it is inactive, finish up, since we either finished speech or desynced.
+        if (!([self readStatus]&STATUS_TS_MASK)) {
+           // If talk status went inactive, shut everything down, we're done.
+           self.speaking = NO;
+           self.index = 0;
+           return;
         }
     }
-        
-    
-    // if we exited speak external mode due to a stop frame in the middle of everything or a general desync, BAIL OUT! Otherwise we get gibberish speak or crashes or other non-fun stuff.
-    if (_tms5220->m_DDIS == 0) {
-        NSLog(@"Fatal tms5220 error, we've desynced and we're no longer in speak external mode. Bailing out.");
-        self.speaking = NO;
-        self.index    = 0;
-    }
-        
+
+    [self fillBuffer:samples]; // Generate some samples
+
 }
 
 -(UserSettings *)userSettings {

--- a/BlueWizard/lib/TMS5220/tms5220.cpp
+++ b/BlueWizard/lib/TMS5220/tms5220.cpp
@@ -518,7 +518,6 @@ void tms5220_device::data_write(int data)
 					m_new_frame_k_idx[i] = 0xF;
 				for (i = 7; i < m_coeff->num_k; i++)
 					m_new_frame_k_idx[i] = 0x7;
-
 			}
 		}
 		else
@@ -528,8 +527,6 @@ void tms5220_device::data_write(int data)
 			// at this point, /READY should remain HIGH/inactive until the fifo has at least one byte open in it.
 #endif
 		}
-
-
 	}
 	else //(! m_DDIS)
 		// R Nabet : we parse commands at once.  It is necessary for such commands as read.

--- a/BlueWizard/lib/TMS5220/tms5220.h
+++ b/BlueWizard/lib/TMS5220/tms5220.h
@@ -59,9 +59,6 @@ public:
 
 	void process(INT16 *buffer, unsigned int size);
     int next_sample();
-	int m_ready_pin;        /* state of the READY pin (output) */
-	int m_fifo_count;
-    UINT8 m_DDIS; /* speak external state, for panic button */
 
     void set_use_raw_excitation_filter(bool yes_or_no);
 
@@ -103,20 +100,21 @@ private:
 	UINT8 m_fifo[FIFO_SIZE];
 	UINT8 m_fifo_head;
 	UINT8 m_fifo_tail;
+	UINT8 m_fifo_count;
 	UINT8 m_fifo_bits_taken;
 
 
 	/* these contain global status bits */
 	UINT8 m_previous_TALK_STATUS;      /* this is the OLD value of TALK_STATUS (i.e. previous value of m_SPEN|m_TALKD), needed for generating interrupts on a falling TALK_STATUS edge */
 	UINT8 m_SPEN;             /* set on speak(or speak external and BL falling edge) command, cleared on stop command, reset command, or buffer out */
-	//UINT8 m_DDIS;             /* If 1, DDIS is 1, i.e. Speak External command in progress, writes go to FIFO. */
+	UINT8 m_DDIS;             /* If 1, DDIS is 1, i.e. Speak External command in progress, writes go to FIFO. */
 	UINT8 m_TALK;             /* set on SPEN & RESETL4(pc12->pc0 transition), cleared on stop command or reset command */
 #define TALK_STATUS (m_SPEN|m_TALKD)
 	UINT8 m_TALKD;            /* TALK(TCON) value, latched every RESETL4 */
 	UINT8 m_buffer_low;       /* If 1, FIFO has less than 8 bytes in it */
 	UINT8 m_buffer_empty;     /* If 1, FIFO is empty */
 	UINT8 m_irq_pin;          /* state of the IRQ pin (output) */
-	//UINT8 m_ready_pin;        /* state of the READY pin (output) */
+	UINT8 m_ready_pin;        /* state of the READY pin (output) */
 
 	/* these contain data describing the current and previous voice frames */
 #define OLD_FRAME_SILENCE_FLAG m_OLDE // 1 if E=0, 0 otherwise.

--- a/BlueWizard/lib/TMS5220/tms5220.h
+++ b/BlueWizard/lib/TMS5220/tms5220.h
@@ -61,6 +61,7 @@ public:
     int next_sample();
 	int m_ready_pin;        /* state of the READY pin (output) */
 	int m_fifo_count;
+    UINT8 m_DDIS; /* speak external state, for panic button */
 
     void set_use_raw_excitation_filter(bool yes_or_no);
 
@@ -108,7 +109,7 @@ private:
 	/* these contain global status bits */
 	UINT8 m_previous_TALK_STATUS;      /* this is the OLD value of TALK_STATUS (i.e. previous value of m_SPEN|m_TALKD), needed for generating interrupts on a falling TALK_STATUS edge */
 	UINT8 m_SPEN;             /* set on speak(or speak external and BL falling edge) command, cleared on stop command, reset command, or buffer out */
-	UINT8 m_DDIS;             /* If 1, DDIS is 1, i.e. Speak External command in progress, writes go to FIFO. */
+	//UINT8 m_DDIS;             /* If 1, DDIS is 1, i.e. Speak External command in progress, writes go to FIFO. */
 	UINT8 m_TALK;             /* set on SPEN & RESETL4(pc12->pc0 transition), cleared on stop command or reset command */
 #define TALK_STATUS (m_SPEN|m_TALKD)
 	UINT8 m_TALKD;            /* TALK(TCON) value, latched every RESETL4 */


### PR DESCRIPTION
Updated the SpeechSynthesizer state machine to appropriately request a reasonable number of samples, and to use the tms5220 status register to decide when to feed data to the tms5220, as well as checking the talk status to decide when our speech sample is 'finished'. This fixes speech samples being cut off too early. Also added a sanity check that makes the speech synthesizer abort with a warning if the tms5220 exits back into command mode due to a stop frame or desync, as well as making it abort with a console warning if there is too little data (<9 bytes) to make the synthesizer start speaking at all.
